### PR TITLE
Fix common_lib dependency to use tag v3.3.4

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
     {gsm0338, "1.0", {git, "https://github.com/AntonSizov/gsm0338.git", {branch, "pure-erlang"}}},
     {oserl, ".*", {git, "git://github.com/PowerMeMobile/oserl.git", {branch, "trx_deadlock_fix_1"}}},
     %% this MUST be here or rebar will fail to include it into escript.
-    {common_lib, "3.3.4", {git, "git://github.com/PowerMeMobile/common_lib.git", {branch, "master"}}}
+    {common_lib, "3.3.4", {git, "git://github.com/PowerMeMobile/common_lib.git", {tag, "v3.3.4"}}}
 ]}.
 {escript_name, "smppload"}.
 {escript_incl_apps, [


### PR DESCRIPTION
Master currently has version 3.3.5 instead of the expected 3.3.4,
which caused `make` to fail the installation.